### PR TITLE
Support for ScaleIO Gateway with no MDMs

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -25,6 +25,14 @@ def collect_scaleio_facts
   facts[:update_time] = Time.now
   facts[:device_type] = "script"
 
+  # ScaleIO MDM is not configured
+  # Need to return basic information
+  if scaleio_cookie == "NO MDM"
+    facts[:general] = {}
+    facts[:general]["name"] = facts[:certname]
+    return facts
+  end
+
   scaleio_system = scaleio_systems[0]
   facts[:general] = scaleio_system
   facts[:statistics] = scaleio_system_statistics(scaleio_system)

--- a/lib/puppet/scaleio/transport.rb
+++ b/lib/puppet/scaleio/transport.rb
@@ -31,6 +31,7 @@ module Puppet
                                                  self.port]
 
         begin
+
           response = RestClient::Request.execute(
               :url => url,
               :method => :get,
@@ -38,7 +39,9 @@ module Puppet
               :payload => '{}',
               :headers => {:content_type => :json,
                            :accept => :json })
+
         rescue => ex
+          response = "NO MDM" if ex.class == RestClient::PreconditionRequired
           Puppet.err "Failed to get cookie from ScaleIO Gateway with error %s" % [ex.message]
         end
         @scaleio_cookie = response.strip.tr('""', '')


### PR DESCRIPTION
Returing basic facts when there is no MDM configured in the ScaleIO gateway and REST APIs are not configured.