### PR TITLE
LUD-537 Work around puppetlabs-firewall failure on EL 7

### DIFF
--- a/manifests/gateway_server.pp
+++ b/manifests/gateway_server.pp
@@ -21,6 +21,8 @@ class scaleio::gateway_server (
     }
   }
   else {
+    ensure_resource('package', ['iptables-services'], {'ensure' => 'installed'})
+
     firewall { '001 for ScaleIO Gateway':
       dport  => [$port, $im_port],
       proto  => tcp,

--- a/manifests/mdm_server.pp
+++ b/manifests/mdm_server.pp
@@ -23,6 +23,8 @@ define scaleio::mdm_server (
     }
   }
   else {
+    ensure_resource('package', ['iptables-services'], {'ensure' => 'installed'})
+
     firewall { '001 Open Ports 6611 and 9011 for ScaleIO MDM':
       dport  => [6611, 9011],
       proto  => tcp,

--- a/manifests/sds_server.pp
+++ b/manifests/sds_server.pp
@@ -9,6 +9,8 @@ define scaleio::sds_server (
   $pkg_path = undef
   )
 {
+  ensure_resource('package', ['iptables-services'], {'ensure' => 'installed'})
+
   firewall { '001 Open Port 7072 for ScaleIO SDS':
     dport  => [7072],
     proto  => tcp,


### PR DESCRIPTION
It appears that if the `iptables-service` rpm is not installed firewall
puppet resources will fail initially. The issue is tracked by
[MODULE-1029][1].

[1]: https://tickets.puppetlabs.com/browse/MODULES-1029