### PR TITLE
LUD-547 ScaleIO login configuration

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -61,7 +61,7 @@ define scaleio::cluster (
       scope_ref           => 'old_password',
       scope_value         => $password,
       approve_certificate => '',
-      unless_query        => "--login --username admin --password $new_password"
+      onlyif_query        => "login --username admin --password $password"
     }
   }
   if $license_file_path {

--- a/manifests/cmd.pp
+++ b/manifests/cmd.pp
@@ -119,7 +119,7 @@ define scaleio::cmd(
     default => "scli ${mdm_opts} ${approve_certificate} --${unless_query} ${val} ${unless_query_ext_opt}"}
   $onlyif_command = $onlyif_query ? {
     undef   => undef,
-    default => "scli ${mdm_opts} ${approve_certificate} --${onlyif_query} ${val}"}
+    default => "scli ${mdm_opts} ${approve_certificate} --${onlyif_query}"}
 
   notify { "SCLI COMMAND: ${command}": }
   if $unless_command {

--- a/manifests/sds_server.pp
+++ b/manifests/sds_server.pp
@@ -43,6 +43,7 @@ define scaleio::sds_server (
   if $xcache == 'present' {
     service { 'xcache':
       ensure => 'running',
+      require => "Scaleio::Package[xcache]"
     }
   }
 


### PR DESCRIPTION
- make sure scaleio login is done with the old password before creating the cluster and updating the new password.
- skip updating the password if it is already updated to the new one
- start SDS services only after sds package is successfully installed