### PR TITLE
LUD-716 Fix default name fact

### DIFF
--- a/bin/discovery.rb
+++ b/bin/discovery.rb
@@ -29,7 +29,7 @@ def collect_scaleio_facts
   # Need to return basic information
   if scaleio_cookie == "NO MDM"
     facts = {
-      :general => { "name" => facts["certname"] },
+      :general => { "name" => facts[:certname] },
       :statistics => {},
       :sdc_list => [],
       :protection_domain_list => [],


### PR DESCRIPTION
Previous commit set `"certname"` instead of `:certname`