### PR TITLE
LUD-1096 Adding parameter revealed a pre-existing error

### DIFF
--- a/manifests/cluster.pp
+++ b/manifests/cluster.pp
@@ -70,10 +70,10 @@ define scaleio::cluster (
   }
   if $license_file_path {
     scaleio::cmd {'set license':
-      action => 'set_license',
-      ref    => 'license_file',
-      value  => $license_file_path},
-      cmd_provider     => $cmd_provider
+      action       => 'set_license',
+      ref          => 'license_file',
+      value        => $license_file_path,
+      cmd_provider => $cmd_provider
   }
   $mdm_opts = $::mdm_ips ? {
     undef   => '',


### PR DESCRIPTION
Even though the `scaleio::cmd` resource wasn't changed, adding a new
parameter resulted in a syntax error:

    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, illegal comma separated argument list (file: /etc/puppetlabs/puppet/modules/scaleio/manifests/cluster.pp, line: 75, column: 36) on node agent-svm-aer11hostc1