### PR TITLE
VXFM-1650 Modify the existing ScaleIO code to add the support for SLES

### DIFF
--- a/manifests/common_server.pp
+++ b/manifests/common_server.pp
@@ -27,6 +27,12 @@ define scaleio::common_server (
       }
     }
   }
+  elsif $::osfamily == 'Suse' {
+    ensure_resource('package', ['libaio', 'numactl', 'wget'], {'ensure' => 'installed'})
+    if $ensure_java == 'present' {
+      ensure_resource('package', 'java-1.8.0-openjdk', {'ensure' => 'installed'})
+    }
+  }
   else {
     fail("Unsupported OS family: ${::osfamily}")
   }

--- a/manifests/mdm_server.pp
+++ b/manifests/mdm_server.pp
@@ -23,16 +23,11 @@ define scaleio::mdm_server (
     }
   }
   else {
-    ensure_resource('package', ['iptables-services'], {'ensure' => 'installed'})
-
     firewall { '001 Open Ports 6611 and 9011 for ScaleIO MDM':
       dport  => [6611, 9011],
       proto  => tcp,
       action => accept,
     }
-    package { ['mutt', 'python', 'python-paramiko']:
-      ensure => installed,
-    } ->
     scaleio::package { 'mdm':
       ensure  => $ensure,
       pkg_ftp => $pkg_ftp,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -25,6 +25,15 @@ define scaleio::package (
       'xcache'  => 'emc-scaleio-xcache',
       'lia'     => 'emc-scaleio-lia',
     },
+    'Suse' => $title ? {
+      'gateway' => 'EMC-ScaleIO-gateway',
+      'gui'     => 'EMC-ScaleIO-gui',
+      'mdm'     => 'EMC-ScaleIO-mdm',
+      'sdc'     => 'EMC-ScaleIO-sdc',
+      'sds'     => 'EMC-ScaleIO-sds',
+      'xcache'  => 'EMC-ScaleIO-xcache',
+      'lia'     => 'EMC-ScaleIO-lia'
+    },
   }
 
   $rel = $::operatingsystemmajrelease ? {
@@ -34,15 +43,18 @@ define scaleio::package (
   $version = $::osfamily ? {
     'RedHat' => "RHEL${rel}",
     'Debian' => "Ubuntu${rel}",
+    'Suse' => "SUSE${rel}",
   }
   $provider = $::osfamily ? {
     'RedHat' => 'rpm',
     'Debian' => 'dpkg',
+    'Suse' => 'rpm',
   }
 
   $pkg_ext = $::osfamily ? {
     'RedHat' => 'rpm',
     'Debian' => 'deb',
+    'Suse' => 'rpm',
   }
 
   if $ensure == 'absent' {

--- a/manifests/sds_server.pp
+++ b/manifests/sds_server.pp
@@ -9,8 +9,6 @@ define scaleio::sds_server (
   $pkg_path = undef
   )
 {
-  ensure_resource('package', ['iptables-services'], {'ensure' => 'installed'})
-
   firewall { '001 Open Port 7072 for ScaleIO SDS':
     dport  => [7072],
     proto  => tcp,


### PR DESCRIPTION
- Removed require of additional packages which are not required any more
- Added support for Suse OS family to make sure all required packages are installed correctly on Suse Linux SVMs